### PR TITLE
Add automatic PDF generation of EN and DE manuals from wiki pages

### DIFF
--- a/.github/workflows/pdf.yml
+++ b/.github/workflows/pdf.yml
@@ -1,0 +1,39 @@
+name: Generate PDF manuals
+
+on:
+  gollum:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+jobs:
+  generate-pdfs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main repo
+        uses: actions/checkout@v4
+        with:
+          repository: ${{github.repository}}
+          path: repo
+      - name: Checkout Wiki
+        uses: actions/checkout@v4
+        with:
+          repository: ${{github.repository}}.wiki
+          path: wiki
+      - name: Install Typst
+        uses: typst-community/setup-typst@v4
+      - name: Install Pandoc
+        uses: pandoc/actions/setup@v1
+        with:
+          version: 3.8.2.1
+      - run: ls -l wiki
+      - name: Build PDFs
+        run: make -C wiki; cp wiki/*.pdf .
+      - name: Upload PDF
+        uses: actions/upload-artifact@v4
+        with:
+          name: manuals
+          path: "*.pdf"


### PR DESCRIPTION
Hi

I wanted to have a offline and PDF version of the manual, so I made a Github workflow for it. This uses Pandoc and Typst to combine a few Markdown files (the manual page, and the appendixes) into a PDF file.

The Makefile and main action is in my fork's wiki page, so that should be pulled and integrated as well.

This is what the actions look like and how people can download the manuals: https://github.com/trygvis/Quansheng_UV-K5_Wiki/actions/runs/18806743191. If a proper release is ever made, the manuals can be attached there.

The content of the manual is not synchronized between the EN and DE versions. I don't know if that is something you would like, but that is something that can be done later, after integrating the build setup.

I like both manuals, the DE version is much more complete but the EN one is the one I want to use as a short reference when adjusting settings. I can never remember what each of those menu options are :)

I've attached two example builds of the manuals as well:

* [Manual_DE.pdf](https://github.com/user-attachments/files/23144096/Manual_DE.pdf)
* [Manual_EN.pdf](https://github.com/user-attachments/files/23144097/Manual_EN.pdf)